### PR TITLE
Update data-providers.mdx

### DIFF
--- a/pages/concepts/basic/data-providers.mdx
+++ b/pages/concepts/basic/data-providers.mdx
@@ -10,3 +10,7 @@ The Data Provider receives a share of the profit that is due to the [Pool](/conc
 
 In contracts infrastructure, the Data Provider is represented as an address to which a part of the profit share
 [is credited](/concepts/basic/rewards) by [LP](/contracts/lp) after the completion of each Condition.
+
+When it comes to resolving the Conditions, the Data Provider on Azuro follows a certain set of rules, derived from one of the most reputable established sports-betting data sources (https://www.pinnacle.com/en/future/betting-rules).
+
+It is envisioned that there may be multiple data providers active on Azuro at a later stage, therefore these rules may change, evolve, or vary depending on the data provider in the future.


### PR DESCRIPTION
Please add a new text below:


When it comes to resolving the Conditions, the Data Provider on Azuro follows a certain set of rules, derived from one of the most reputable established sports-betting data sources (https://www.pinnacle.com/en/future/betting-rules).

It is envisioned that there may be multiple data providers active on Azuro at a later stage, therefore these rules may change, evolve, or vary depending on the data provider in the future.